### PR TITLE
Migrate to Renderer2

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   },
   "peerDependencies": {},
   "devDependencies": {
+    "lite-server": "^2.5.4",
     "@angular-devkit/build-angular": "~0.11.0",
     "@angular/cli": "^7.1.4",
     "@angular/common": "^7.2.0",
@@ -65,8 +66,8 @@
     "@angular/router": "^7.2.0",
     "@types/marked": "0.0.28",
     "@types/node": "7.0.0",
-    "@types/tapable": "^0.2.5",
-    "@types/webpack": "^2.2.2",
+    "@types/tapable": "^1.0.4",
+    "@types/webpack": "^4.39.5",
     "classlist-polyfill": "1.0.3",
     "ngm-cli": "^1.0.4",
     "rxjs": "^6.3.3",

--- a/src/view/view.directive.ts
+++ b/src/view/view.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, Renderer, Input, Output, Optional, EventEmitter } from '@angular/core';
+import { Directive, ElementRef, Renderer2, Input } from '@angular/core';
 
 @Directive({
   selector: '[froalaView]'
@@ -6,9 +6,8 @@ import { Directive, ElementRef, Renderer, Input, Output, Optional, EventEmitter 
 export class FroalaViewDirective {
 
   private _element: HTMLElement;
-  private _content: any;
 
-  constructor(private renderer: Renderer, element: ElementRef) {
+  constructor(private renderer: Renderer2, element: ElementRef) {
     this._element = element.nativeElement;
   }
 
@@ -18,6 +17,6 @@ export class FroalaViewDirective {
   }
 
   ngAfterViewInit() {
-    this.renderer.setElementClass(this._element, "fr-view", true);
+    this.renderer.addClass(this._element, "fr-view");
   }
 }


### PR DESCRIPTION
In the [Angular validation repo](https://github.com/angular/ngcc-validation) we detected that you're still using an API that we're removing as part of Angular version 9. This PR will make your app compatible with the latest versions of the framework.

I've also updated few typings because of compile-time errors, and added `lite-server` so you can easily see the demo app.

Fix https://github.com/froala/angular-froala-wysiwyg/pull/349.