### PR TITLE
Removed the unnecessary stylesheet from the instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ import { FroalaEditorModule, FroalaViewModule } from 'angular-froala-wysiwyg';
 
 ```json
 "styles": [
-  "styles.css",
   "./node_modules/froala-editor/css/froala_editor.pkgd.min.css",
   "./node_modules/froala-editor/css/froala_style.min.css",
   "./node_modules/font-awesome/css/font-awesome.css"


### PR DESCRIPTION
[#2700](https://github.com/froala-labs/froala-editor-js-2/issues/2700)