### PR TITLE
Update editor.module.ts

### DIFF
--- a/src/editor/editor.module.ts
+++ b/src/editor/editor.module.ts
@@ -8,7 +8,7 @@ import { FroalaEditorDirective } from './editor.directive';
 })
 
 export class FroalaEditorModule {
-  public static forRoot(): ModuleWithProviders {
+  public static forRoot(): ModuleWithProviders<FroalaEditorModule> {
     return {ngModule: FroalaEditorModule, providers: []};
   }
 }


### PR DESCRIPTION
Fix #378 as https://angular.io/guide/deprecations#modulewithproviders-type-without-a-generic