### PR TITLE
Fix type errors and missing import of Renderer when running with Angular 9.1.7

### DIFF
--- a/src/editor/editor.directive.ts
+++ b/src/editor/editor.directive.ts
@@ -1,5 +1,5 @@
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from "@angular/forms";
-import { Directive, ElementRef, EventEmitter, Input, NgZone, Optional, Output, Renderer, forwardRef } from '@angular/core';
+import { Directive, ElementRef, EventEmitter, Input, NgZone, Output, forwardRef } from '@angular/core';
 
 import FroalaEditor from 'froala-editor';
 

--- a/src/editor/editor.module.ts
+++ b/src/editor/editor.module.ts
@@ -8,7 +8,7 @@ import { FroalaEditorDirective } from './editor.directive';
 })
 
 export class FroalaEditorModule {
-  public static forRoot(): ModuleWithProviders {
+  public static forRoot(): ModuleWithProviders<FroalaEditorModule> {
     return {ngModule: FroalaEditorModule, providers: []};
   }
 }

--- a/src/view/view.module.ts
+++ b/src/view/view.module.ts
@@ -7,7 +7,7 @@ import { FroalaViewDirective } from './view.directive';
   exports: [FroalaViewDirective]
 })
 export class FroalaViewModule {
-  public static forRoot(): ModuleWithProviders {
+  public static forRoot(): ModuleWithProviders<FroalaViewModule> {
     return {ngModule: FroalaViewModule, providers: []};
   }
 }


### PR DESCRIPTION
This fixes 2 type errors and one unused import with Renderer which doesn't resolve when IVY is enabled.