### PR TITLE
Adding generic to ModuleWithProviders -- Angular9 + support

### DIFF
--- a/src/editor/editor.module.ts
+++ b/src/editor/editor.module.ts
@@ -8,7 +8,7 @@ import { FroalaEditorDirective } from './editor.directive';
 })
 
 export class FroalaEditorModule {
-  public static forRoot(): ModuleWithProviders {
+  public static forRoot(): ModuleWithProviders<FroalaEditorModule>{
     return {ngModule: FroalaEditorModule, providers: []};
   }
 }

--- a/src/view/view.module.ts
+++ b/src/view/view.module.ts
@@ -7,7 +7,7 @@ import { FroalaViewDirective } from './view.directive';
   exports: [FroalaViewDirective]
 })
 export class FroalaViewModule {
-  public static forRoot(): ModuleWithProviders {
+  public static forRoot(): ModuleWithProviders<FroalaViewModule> {
     return {ngModule: FroalaViewModule, providers: []};
   }
 }


### PR DESCRIPTION
Adding generic to ModuleWithProviders -- 
Angular 9 plans in future versions to make ModuleWithProviders require generic.

Here: 
_Angular version 9 deprecates use of ModuleWithProviders without an explicitly generic type, where the generic type refers to the type of the NgModule. In a future version of Angular, the generic will no longer be optional._
https://angular.io/guide/deprecations

_If you are a library author and you had a method returning ModuleWithProviders (typically via a method named forRoot()), you will need to specify the generic type. Learn more angular.io_
https://update.angular.io/

We use 2.9.8 Froala-Editor + Angular Froala WYSIWYG.
Thank you to consider merging this PR to another 2xx branch -- as we don't have a roadmap to update 3.1.1 in the near future.