### PR TITLE
master-1823

### DIFF
--- a/src/editor/editor.directive.ts
+++ b/src/editor/editor.directive.ts
@@ -174,9 +174,7 @@ export class FroalaEditorDirective implements ControlValueAccessor {
     if (this._editor.events) {
       // bind contentChange and keyup event to froalaModel
       this._editor.events.on('contentChanged', function () {
-        setTimeout(function () {
-          self.updateModel();
-        }, 0);
+        self.updateModel();
       });
       this._editor.events.on('mousedown', function () {
         setTimeout(function () {


### PR DESCRIPTION
Fixed issue, contentChanged event is triggered before binding is updated.

Ticket(s): https://github.com/froala-labs/froala-editor-js-2/issues/1823