### PR TITLE
run setup code early if writeValue has content. fixes #331

### DIFF
--- a/src/editor/editor.directive.ts
+++ b/src/editor/editor.directive.ts
@@ -56,6 +56,9 @@ export class FroalaEditorDirective implements ControlValueAccessor {
   // Form model content changed.
   writeValue(content: any): void {
     this.updateEditor(content);
+   if(content){
+      this.setup();
+    }
   }
 
   registerOnChange(fn: (_: any) => void): void { this.onChange = fn; }
@@ -346,6 +349,14 @@ export class FroalaEditorDirective implements ControlValueAccessor {
   // TODO not sure if ngOnInit is executed after @inputs
   ngAfterViewInit() {
     // check if output froalaInit is present. Maybe observers is private and should not be used?? TODO how to better test that an output directive is present.
+   this.setup();
+  }
+
+  private initialized = false;
+  private setup() {
+    if (this.initialized) {
+      return;
+    }
     if (!this.froalaInit.observers.length) {
       this.createEditor();
     } else {


### PR DESCRIPTION
Running setup early when data is bound with control value accessors fixes issue #331 