### PR TITLE
Upgrade to ivy

### DIFF
--- a/projects/library/tsconfig.json
+++ b/projects/library/tsconfig.json
@@ -19,7 +19,7 @@
     "types": []
   },
   "angularCompilerOptions": {
-    "enableIvy": false,
+    "enableIvy": true,
     "annotateForClosureCompiler": true,
     "strictMetadataEmit": true,
     "skipTemplateCodegen": true,


### PR DESCRIPTION
Change the builder to ivy to be compatible with angular 15. It is a breaking change since it can't be used with the view engine anymore. Related to #505